### PR TITLE
Add interactive chart legend filtering to analytics dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart legend filtering is now additive — clicking a bot or type shows only that item instead of hiding it; clicking it again shows all
+- Clicking a chart legend item now updates the bot breakdown table, request types table, most accessed pages table, and stats cards to reflect the selected filter
+
 ## [1.3.1] - 2026-03-27
 
 ### Changed

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -252,6 +252,17 @@ LLM Ready includes an opt-in analytics dashboard that tracks AI bot requests to 
 
 Once enabled, a **LLM Ready** section appears in the control panel navigation with a dashboard showing requests over time, bot breakdown, most accessed pages, and request type breakdown.
 
+### Filtering by bot or request type
+
+Switch the chart to the **By Bot** or **By Type** view using the toggle buttons, then click any legend item to filter the entire dashboard to that bot or type. When a filter is active:
+
+- The chart shows only the selected item.
+- The stats cards (Total Requests, Unique Bots, Content Types Served) update to reflect the filtered data.
+- The bot breakdown, request types, and most accessed pages tables all update to show only data matching the filter.
+- A **Filtered: [name]** indicator appears with a **Clear** button to remove the filter.
+
+Click the same legend item again or press **Clear** to restore the full (unfiltered) view. Switching chart views or changing the date range also clears any active filter.
+
 ### Request types
 
 The analytics dashboard groups requests into four types:

--- a/src/controllers/AnalyticsController.php
+++ b/src/controllers/AnalyticsController.php
@@ -74,7 +74,13 @@ class AnalyticsController extends Controller
         };
 
         $botName = $request->getParam('botName') ?: null;
+        if ($botName !== null) {
+            $botName = array_map('trim', explode(',', $botName));
+        }
         $requestType = $request->getParam('requestType') ?: null;
+        if ($requestType !== null) {
+            $requestType = array_map('trim', explode(',', $requestType));
+        }
 
         $analyticsService = LlmReady::getInstance()->analyticsService;
 

--- a/src/controllers/AnalyticsController.php
+++ b/src/controllers/AnalyticsController.php
@@ -73,16 +73,19 @@ class AnalyticsController extends Controller
             default => 'day',
         };
 
+        $botName = $request->getParam('botName') ?: null;
+        $requestType = $request->getParam('requestType') ?: null;
+
         $analyticsService = LlmReady::getInstance()->analyticsService;
 
         return $this->asJson([
-            'totalRequests' => $analyticsService->getTotalRequests($siteId, $startDate, $endDate),
-            'requestsOverTime' => $analyticsService->getRequestsOverTime($siteId, $startDate, $endDate, $granularity),
-            'requestsOverTimeByBot' => $analyticsService->getRequestsOverTimeByBot($siteId, $startDate, $endDate, $granularity),
-            'requestsOverTimeByType' => $analyticsService->getRequestsOverTimeByType($siteId, $startDate, $endDate, $granularity),
-            'botBreakdown' => $analyticsService->getBotBreakdown($siteId, $startDate, $endDate),
-            'requestTypeBreakdown' => $analyticsService->getRequestTypeBreakdown($siteId, $startDate, $endDate),
-            'mostAccessedPages' => $analyticsService->getMostAccessedPages($siteId, $startDate, $endDate),
+            'totalRequests' => $analyticsService->getTotalRequests($siteId, $startDate, $endDate, $botName, $requestType),
+            'requestsOverTime' => $analyticsService->getRequestsOverTime($siteId, $startDate, $endDate, $granularity, $botName, $requestType),
+            'requestsOverTimeByBot' => $analyticsService->getRequestsOverTimeByBot($siteId, $startDate, $endDate, $granularity, $botName, $requestType),
+            'requestsOverTimeByType' => $analyticsService->getRequestsOverTimeByType($siteId, $startDate, $endDate, $granularity, $botName, $requestType),
+            'botBreakdown' => $analyticsService->getBotBreakdown($siteId, $startDate, $endDate, $botName, $requestType),
+            'requestTypeBreakdown' => $analyticsService->getRequestTypeBreakdown($siteId, $startDate, $endDate, $botName, $requestType),
+            'mostAccessedPages' => $analyticsService->getMostAccessedPages($siteId, $startDate, $endDate, 20, $botName, $requestType),
         ]);
     }
 

--- a/src/services/AnalyticsService.php
+++ b/src/services/AnalyticsService.php
@@ -64,11 +64,25 @@ class AnalyticsService extends Component
     }
 
     /**
+     * Apply optional bot/type filter conditions to a query
+     */
+    private function applyFilters(Query $query, ?string $botName, ?string $requestType): Query
+    {
+        if ($botName !== null) {
+            $query->andWhere(['botName' => $botName]);
+        }
+        if ($requestType !== null) {
+            $query->andWhere(['requestType' => $requestType]);
+        }
+        return $query;
+    }
+
+    /**
      * Get request counts over time grouped by granularity
      *
      * @return array<int, array{date: string, count: int}>
      */
-    public function getRequestsOverTime(int $siteId, string $startDate, string $endDate, string $granularity = 'day'): array
+    public function getRequestsOverTime(int $siteId, string $startDate, string $endDate, string $granularity = 'day', ?string $botName = null, ?string $requestType = null): array
     {
         $dateExpr = match ($granularity) {
             'week' => 'DATE(DATE_SUB([[dateCreated]], INTERVAL WEEKDAY([[dateCreated]]) DAY))',
@@ -76,13 +90,16 @@ class AnalyticsService extends Component
             default => 'DATE([[dateCreated]])',
         };
 
-        return (new Query())
+        $query = (new Query())
             ->select(["date" => $dateExpr, 'count' => 'COUNT(*)'])
             ->from(AnalyticsRecord::tableName())
             ->where(['siteId' => $siteId])
             ->andWhere(['>=', 'dateCreated', $startDate])
-            ->andWhere(['<=', 'dateCreated', $endDate])
-            ->groupBy([$dateExpr])
+            ->andWhere(['<=', 'dateCreated', $endDate]);
+
+        $this->applyFilters($query, $botName, $requestType);
+
+        return $query->groupBy([$dateExpr])
             ->orderBy(['date' => SORT_ASC])
             ->all();
     }
@@ -92,7 +109,7 @@ class AnalyticsService extends Component
      *
      * @return array<string, array<int, array{date: string, count: int}>>
      */
-    public function getRequestsOverTimeByBot(int $siteId, string $startDate, string $endDate, string $granularity = 'day'): array
+    public function getRequestsOverTimeByBot(int $siteId, string $startDate, string $endDate, string $granularity = 'day', ?string $botName = null, ?string $requestType = null): array
     {
         $dateExpr = match ($granularity) {
             'week' => 'DATE(DATE_SUB([[dateCreated]], INTERVAL WEEKDAY([[dateCreated]]) DAY))',
@@ -100,13 +117,16 @@ class AnalyticsService extends Component
             default => 'DATE([[dateCreated]])',
         };
 
-        $rows = (new Query())
+        $query = (new Query())
             ->select(["date" => $dateExpr, 'botName', 'count' => 'COUNT(*)'])
             ->from(AnalyticsRecord::tableName())
             ->where(['siteId' => $siteId])
             ->andWhere(['>=', 'dateCreated', $startDate])
-            ->andWhere(['<=', 'dateCreated', $endDate])
-            ->groupBy([$dateExpr, 'botName'])
+            ->andWhere(['<=', 'dateCreated', $endDate]);
+
+        $this->applyFilters($query, $botName, $requestType);
+
+        $rows = $query->groupBy([$dateExpr, 'botName'])
             ->orderBy(['date' => SORT_ASC])
             ->all();
 
@@ -126,7 +146,7 @@ class AnalyticsService extends Component
      *
      * @return array<string, array<int, array{date: string, count: int}>>
      */
-    public function getRequestsOverTimeByType(int $siteId, string $startDate, string $endDate, string $granularity = 'day'): array
+    public function getRequestsOverTimeByType(int $siteId, string $startDate, string $endDate, string $granularity = 'day', ?string $botName = null, ?string $requestType = null): array
     {
         $dateExpr = match ($granularity) {
             'week' => 'DATE(DATE_SUB([[dateCreated]], INTERVAL WEEKDAY([[dateCreated]]) DAY))',
@@ -134,13 +154,16 @@ class AnalyticsService extends Component
             default => 'DATE([[dateCreated]])',
         };
 
-        $rows = (new Query())
+        $query = (new Query())
             ->select(["date" => $dateExpr, 'requestType', 'count' => 'COUNT(*)'])
             ->from(AnalyticsRecord::tableName())
             ->where(['siteId' => $siteId])
             ->andWhere(['>=', 'dateCreated', $startDate])
-            ->andWhere(['<=', 'dateCreated', $endDate])
-            ->groupBy([$dateExpr, 'requestType'])
+            ->andWhere(['<=', 'dateCreated', $endDate]);
+
+        $this->applyFilters($query, $botName, $requestType);
+
+        $rows = $query->groupBy([$dateExpr, 'requestType'])
             ->orderBy(['date' => SORT_ASC])
             ->all();
 
@@ -160,9 +183,9 @@ class AnalyticsService extends Component
      *
      * @return array<int, array{botName: string, count: int, lastSeen: string}>
      */
-    public function getBotBreakdown(int $siteId, string $startDate, string $endDate): array
+    public function getBotBreakdown(int $siteId, string $startDate, string $endDate, ?string $botName = null, ?string $requestType = null): array
     {
-        $rows = (new Query())
+        $query = (new Query())
             ->select([
                 'botName',
                 'count' => 'COUNT(*)',
@@ -171,8 +194,11 @@ class AnalyticsService extends Component
             ->from(AnalyticsRecord::tableName())
             ->where(['siteId' => $siteId])
             ->andWhere(['>=', 'dateCreated', $startDate])
-            ->andWhere(['<=', 'dateCreated', $endDate])
-            ->groupBy(['botName'])
+            ->andWhere(['<=', 'dateCreated', $endDate]);
+
+        $this->applyFilters($query, $botName, $requestType);
+
+        $rows = $query->groupBy(['botName'])
             ->orderBy(['count' => SORT_DESC])
             ->all();
 
@@ -194,9 +220,9 @@ class AnalyticsService extends Component
      *
      * @return array<int, array{requestType: string, count: int}>
      */
-    public function getRequestTypeBreakdown(int $siteId, string $startDate, string $endDate): array
+    public function getRequestTypeBreakdown(int $siteId, string $startDate, string $endDate, ?string $botName = null, ?string $requestType = null): array
     {
-        return (new Query())
+        $query = (new Query())
             ->select([
                 'requestType',
                 'count' => 'COUNT(*)',
@@ -204,8 +230,11 @@ class AnalyticsService extends Component
             ->from(AnalyticsRecord::tableName())
             ->where(['siteId' => $siteId])
             ->andWhere(['>=', 'dateCreated', $startDate])
-            ->andWhere(['<=', 'dateCreated', $endDate])
-            ->groupBy(['requestType'])
+            ->andWhere(['<=', 'dateCreated', $endDate]);
+
+        $this->applyFilters($query, $botName, $requestType);
+
+        return $query->groupBy(['requestType'])
             ->orderBy(['count' => SORT_DESC])
             ->all();
     }
@@ -215,9 +244,9 @@ class AnalyticsService extends Component
      *
      * @return array<int, array{requestPath: string, requestType: string, count: int, cpEditUrl: string|null}>
      */
-    public function getMostAccessedPages(int $siteId, string $startDate, string $endDate, int $limit = 20): array
+    public function getMostAccessedPages(int $siteId, string $startDate, string $endDate, int $limit = 20, ?string $botName = null, ?string $requestType = null): array
     {
-        $rows = (new Query())
+        $query = (new Query())
             ->select([
                 'requestPath',
                 'requestType',
@@ -227,8 +256,11 @@ class AnalyticsService extends Component
             ->from(AnalyticsRecord::tableName())
             ->where(['siteId' => $siteId])
             ->andWhere(['>=', 'dateCreated', $startDate])
-            ->andWhere(['<=', 'dateCreated', $endDate])
-            ->groupBy(['requestPath', 'requestType'])
+            ->andWhere(['<=', 'dateCreated', $endDate]);
+
+        $this->applyFilters($query, $botName, $requestType);
+
+        $rows = $query->groupBy(['requestPath', 'requestType'])
             ->orderBy(['count' => SORT_DESC])
             ->limit($limit)
             ->all();
@@ -256,14 +288,17 @@ class AnalyticsService extends Component
     /**
      * Get total request count for a date range
      */
-    public function getTotalRequests(int $siteId, string $startDate, string $endDate): int
+    public function getTotalRequests(int $siteId, string $startDate, string $endDate, ?string $botName = null, ?string $requestType = null): int
     {
-        return (int) (new Query())
+        $query = (new Query())
             ->from(AnalyticsRecord::tableName())
             ->where(['siteId' => $siteId])
             ->andWhere(['>=', 'dateCreated', $startDate])
-            ->andWhere(['<=', 'dateCreated', $endDate])
-            ->count();
+            ->andWhere(['<=', 'dateCreated', $endDate]);
+
+        $this->applyFilters($query, $botName, $requestType);
+
+        return (int) $query->count();
     }
 
     /**

--- a/src/services/AnalyticsService.php
+++ b/src/services/AnalyticsService.php
@@ -66,7 +66,7 @@ class AnalyticsService extends Component
     /**
      * Apply optional bot/type filter conditions to a query
      */
-    private function applyFilters(Query $query, ?string $botName, ?string $requestType): Query
+    private function applyFilters(Query $query, string|array|null $botName, string|array|null $requestType): Query
     {
         if ($botName !== null) {
             $query->andWhere(['botName' => $botName]);
@@ -82,7 +82,7 @@ class AnalyticsService extends Component
      *
      * @return array<int, array{date: string, count: int}>
      */
-    public function getRequestsOverTime(int $siteId, string $startDate, string $endDate, string $granularity = 'day', ?string $botName = null, ?string $requestType = null): array
+    public function getRequestsOverTime(int $siteId, string $startDate, string $endDate, string $granularity = 'day', string|array|null $botName = null, string|array|null $requestType = null): array
     {
         $dateExpr = match ($granularity) {
             'week' => 'DATE(DATE_SUB([[dateCreated]], INTERVAL WEEKDAY([[dateCreated]]) DAY))',
@@ -109,7 +109,7 @@ class AnalyticsService extends Component
      *
      * @return array<string, array<int, array{date: string, count: int}>>
      */
-    public function getRequestsOverTimeByBot(int $siteId, string $startDate, string $endDate, string $granularity = 'day', ?string $botName = null, ?string $requestType = null): array
+    public function getRequestsOverTimeByBot(int $siteId, string $startDate, string $endDate, string $granularity = 'day', string|array|null $botName = null, string|array|null $requestType = null): array
     {
         $dateExpr = match ($granularity) {
             'week' => 'DATE(DATE_SUB([[dateCreated]], INTERVAL WEEKDAY([[dateCreated]]) DAY))',
@@ -146,7 +146,7 @@ class AnalyticsService extends Component
      *
      * @return array<string, array<int, array{date: string, count: int}>>
      */
-    public function getRequestsOverTimeByType(int $siteId, string $startDate, string $endDate, string $granularity = 'day', ?string $botName = null, ?string $requestType = null): array
+    public function getRequestsOverTimeByType(int $siteId, string $startDate, string $endDate, string $granularity = 'day', string|array|null $botName = null, string|array|null $requestType = null): array
     {
         $dateExpr = match ($granularity) {
             'week' => 'DATE(DATE_SUB([[dateCreated]], INTERVAL WEEKDAY([[dateCreated]]) DAY))',
@@ -183,7 +183,7 @@ class AnalyticsService extends Component
      *
      * @return array<int, array{botName: string, count: int, lastSeen: string}>
      */
-    public function getBotBreakdown(int $siteId, string $startDate, string $endDate, ?string $botName = null, ?string $requestType = null): array
+    public function getBotBreakdown(int $siteId, string $startDate, string $endDate, string|array|null $botName = null, string|array|null $requestType = null): array
     {
         $query = (new Query())
             ->select([
@@ -220,7 +220,7 @@ class AnalyticsService extends Component
      *
      * @return array<int, array{requestType: string, count: int}>
      */
-    public function getRequestTypeBreakdown(int $siteId, string $startDate, string $endDate, ?string $botName = null, ?string $requestType = null): array
+    public function getRequestTypeBreakdown(int $siteId, string $startDate, string $endDate, string|array|null $botName = null, string|array|null $requestType = null): array
     {
         $query = (new Query())
             ->select([
@@ -244,7 +244,7 @@ class AnalyticsService extends Component
      *
      * @return array<int, array{requestPath: string, requestType: string, count: int, cpEditUrl: string|null}>
      */
-    public function getMostAccessedPages(int $siteId, string $startDate, string $endDate, int $limit = 20, ?string $botName = null, ?string $requestType = null): array
+    public function getMostAccessedPages(int $siteId, string $startDate, string $endDate, int $limit = 20, string|array|null $botName = null, string|array|null $requestType = null): array
     {
         $query = (new Query())
             ->select([
@@ -288,7 +288,7 @@ class AnalyticsService extends Component
     /**
      * Get total request count for a date range
      */
-    public function getTotalRequests(int $siteId, string $startDate, string $endDate, ?string $botName = null, ?string $requestType = null): int
+    public function getTotalRequests(int $siteId, string $startDate, string $endDate, string|array|null $botName = null, string|array|null $requestType = null): int
     {
         $query = (new Query())
             ->from(AnalyticsRecord::tableName())

--- a/src/templates/analytics/index.twig
+++ b/src/templates/analytics/index.twig
@@ -42,17 +42,21 @@
             </div>
             <div class="stat-card">
                 <h4>Unique Bots</h4>
-                <div class="stat-value">{{ data.botBreakdown|length }}</div>
+                <div class="stat-value" id="uniqueBots">{{ data.botBreakdown|length }}</div>
             </div>
             <div class="stat-card">
                 <h4>Content Types Served</h4>
-                <div class="stat-value">{{ data.requestTypeBreakdown|length }}</div>
+                <div class="stat-value" id="contentTypes">{{ data.requestTypeBreakdown|length }}</div>
             </div>
         </div>
 
         <div class="dashboard-section">
             <div class="chart-header">
                 <h3>Requests Over Time</h3>
+                <span class="active-filter" id="activeFilter" style="display: none;">
+                    Filtered: <strong id="activeFilterValue"></strong>
+                    <button type="button" class="btn small" id="clearFilter">Clear</button>
+                </span>
                 <div class="chart-view-toggle" id="chartViewToggle">
                     <button type="button" class="chart-toggle-btn active" data-view="total">Total</button>
                     <button type="button" class="chart-toggle-btn" data-view="bot">By Bot</button>

--- a/src/web/assets/analytics/css/dashboard.css
+++ b/src/web/assets/analytics/css/dashboard.css
@@ -35,6 +35,18 @@
     margin: 0;
 }
 
+.llm-ready-dashboard .active-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--medium-text-color, #8f98a3);
+}
+
+.llm-ready-dashboard .active-filter strong {
+    color: var(--text-color, #3f4d5a);
+}
+
 .llm-ready-dashboard .chart-view-toggle {
     display: inline-flex;
     border: 1px solid var(--hairline-color, #e3e5e8);

--- a/src/web/assets/analytics/js/dashboard.js
+++ b/src/web/assets/analytics/js/dashboard.js
@@ -4,6 +4,7 @@
     let chart = null;
     let currentView = 'total';
     let currentData = null;
+    let activeFilter = null; // null or { type: 'bot'|'type', value: string }
 
     // Color palette for stacked chart segments
     var COLORS = [
@@ -18,7 +19,7 @@
     ];
 
     function initDashboard() {
-        const chartCanvas = document.getElementById('requestsChart');
+        var chartCanvas = document.getElementById('requestsChart');
         if (!chartCanvas) return;
 
         currentData = JSON.parse(document.getElementById('chartData').textContent);
@@ -33,6 +34,8 @@
                 if (view === currentView) return;
 
                 currentView = view;
+                activeFilter = null;
+                updateFilterIndicator();
                 toggleContainer.querySelectorAll('.chart-toggle-btn').forEach(function(b) {
                     b.classList.remove('active');
                 });
@@ -41,25 +44,49 @@
             });
         }
 
-        const rangeSelect = document.getElementById('dateRange');
-        const siteSelect = document.getElementById('siteSelect');
+        var rangeSelect = document.getElementById('dateRange');
+        var siteSelect = document.getElementById('siteSelect');
 
         if (rangeSelect) {
-            rangeSelect.addEventListener('change', fetchData);
+            rangeSelect.addEventListener('change', function() {
+                activeFilter = null;
+                updateFilterIndicator();
+                fetchData();
+            });
         }
         if (siteSelect) {
-            siteSelect.addEventListener('change', fetchData);
+            siteSelect.addEventListener('change', function() {
+                activeFilter = null;
+                updateFilterIndicator();
+                fetchData();
+            });
+        }
+
+        var clearBtn = document.getElementById('clearFilter');
+        if (clearBtn) {
+            clearBtn.addEventListener('click', function() {
+                activeFilter = null;
+                updateFilterIndicator();
+                fetchData();
+            });
         }
     }
 
     function fetchData() {
-        const range = document.getElementById('dateRange').value;
-        const siteSelect = document.getElementById('siteSelect');
-        const siteId = siteSelect ? siteSelect.value : '';
+        var range = document.getElementById('dateRange').value;
+        var siteSelect = document.getElementById('siteSelect');
+        var siteId = siteSelect ? siteSelect.value : '';
 
-        const params = new URLSearchParams({ range: range });
+        var params = new URLSearchParams({ range: range });
         if (siteId) {
             params.set('siteId', siteId);
+        }
+        if (activeFilter) {
+            if (activeFilter.type === 'bot') {
+                params.set('botName', activeFilter.value);
+            } else if (activeFilter.type === 'type') {
+                params.set('requestType', activeFilter.value);
+            }
         }
 
         fetch(Craft.getActionUrl('llm-ready/analytics/data') + '?' + params.toString(), {
@@ -82,6 +109,16 @@
         var totalEl = document.getElementById('totalRequests');
         if (totalEl) {
             totalEl.textContent = data.totalRequests.toLocaleString();
+        }
+
+        var botsEl = document.getElementById('uniqueBots');
+        if (botsEl) {
+            botsEl.textContent = data.botBreakdown.length;
+        }
+
+        var typesEl = document.getElementById('contentTypes');
+        if (typesEl) {
+            typesEl.textContent = data.requestTypeBreakdown.length;
         }
 
         renderChart();
@@ -216,6 +253,20 @@
                             padding: 16,
                             font: { size: 11 },
                         },
+                        onClick: function(e, legendItem) {
+                            var clickedLabel = legendItem.text;
+
+                            if (activeFilter && activeFilter.value === clickedLabel) {
+                                // Clicking the active filter clears it
+                                activeFilter = null;
+                            } else {
+                                // Additive: show only this item
+                                activeFilter = { type: currentView, value: clickedLabel };
+                            }
+
+                            updateFilterIndicator();
+                            fetchData();
+                        },
                     },
                 },
                 scales: {
@@ -231,6 +282,19 @@
                 },
             },
         };
+    }
+
+    function updateFilterIndicator() {
+        var el = document.getElementById('activeFilter');
+        var valueEl = document.getElementById('activeFilterValue');
+        if (!el || !valueEl) return;
+
+        if (activeFilter) {
+            valueEl.textContent = activeFilter.value;
+            el.style.display = '';
+        } else {
+            el.style.display = 'none';
+        }
     }
 
     function clearElement(el) {

--- a/src/web/assets/analytics/js/dashboard.js
+++ b/src/web/assets/analytics/js/dashboard.js
@@ -312,7 +312,7 @@
                                         lineWidth: 1,
                                         hidden: false,
                                         datasetIndex: i,
-                                        fontColor: isSelected ? undefined : 'rgba(150, 150, 150, 0.6)',
+                                        fontColor: isSelected ? '#3f4d5a' : 'rgba(150, 150, 150, 0.6)',
                                     };
                                 });
                             },

--- a/src/web/assets/analytics/js/dashboard.js
+++ b/src/web/assets/analytics/js/dashboard.js
@@ -1,10 +1,11 @@
 (function() {
     'use strict';
 
-    let chart = null;
-    let currentView = 'total';
-    let currentData = null;
-    let activeFilter = null; // null or { type: 'bot'|'type', value: string }
+    var chart = null;
+    var currentView = 'total';
+    var currentData = null;
+    var activeFilters = []; // Array of selected legend item names
+    var filterType = null;  // 'bot' or 'type'
 
     // Color palette for stacked chart segments
     var COLORS = [
@@ -17,6 +18,8 @@
         { bg: 'rgba(232, 108, 64, 0.7)',  border: 'rgba(232, 108, 64, 1)' },
         { bg: 'rgba(165, 125, 86, 0.7)',  border: 'rgba(165, 125, 86, 1)' },
     ];
+
+    var GRAY = { bg: 'rgba(200, 200, 200, 0.15)', border: 'rgba(200, 200, 200, 0.4)' };
 
     function initDashboard() {
         var chartCanvas = document.getElementById('requestsChart');
@@ -34,8 +37,7 @@
                 if (view === currentView) return;
 
                 currentView = view;
-                activeFilter = null;
-                updateFilterIndicator();
+                clearFilters();
                 toggleContainer.querySelectorAll('.chart-toggle-btn').forEach(function(b) {
                     b.classList.remove('active');
                 });
@@ -49,15 +51,13 @@
 
         if (rangeSelect) {
             rangeSelect.addEventListener('change', function() {
-                activeFilter = null;
-                updateFilterIndicator();
+                clearFilters();
                 fetchData();
             });
         }
         if (siteSelect) {
             siteSelect.addEventListener('change', function() {
-                activeFilter = null;
-                updateFilterIndicator();
+                clearFilters();
                 fetchData();
             });
         }
@@ -65,11 +65,16 @@
         var clearBtn = document.getElementById('clearFilter');
         if (clearBtn) {
             clearBtn.addEventListener('click', function() {
-                activeFilter = null;
-                updateFilterIndicator();
-                fetchData();
+                clearFilters();
+                restoreUnfilteredTables();
             });
         }
+    }
+
+    function clearFilters() {
+        activeFilters = [];
+        filterType = null;
+        updateFilterIndicator();
     }
 
     function fetchData() {
@@ -80,13 +85,6 @@
         var params = new URLSearchParams({ range: range });
         if (siteId) {
             params.set('siteId', siteId);
-        }
-        if (activeFilter) {
-            if (activeFilter.type === 'bot') {
-                params.set('botName', activeFilter.value);
-            } else if (activeFilter.type === 'type') {
-                params.set('requestType', activeFilter.value);
-            }
         }
 
         fetch(Craft.getActionUrl('llm-ready/analytics/data') + '?' + params.toString(), {
@@ -105,26 +103,71 @@
         });
     }
 
+    function fetchFilteredTables() {
+        var range = document.getElementById('dateRange').value;
+        var siteSelect = document.getElementById('siteSelect');
+        var siteId = siteSelect ? siteSelect.value : '';
+
+        var params = new URLSearchParams({ range: range });
+        if (siteId) {
+            params.set('siteId', siteId);
+        }
+
+        if (filterType === 'bot') {
+            params.set('botName', activeFilters.join(','));
+        } else if (filterType === 'type') {
+            params.set('requestType', activeFilters.join(','));
+        }
+
+        fetch(Craft.getActionUrl('llm-ready/analytics/data') + '?' + params.toString(), {
+            headers: {
+                'Accept': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest',
+            },
+        })
+        .then(function(response) { return response.json(); })
+        .then(function(data) {
+            // Update only tables and stats — chart stays as-is
+            updateStats(data);
+            updateBotTable(data.botBreakdown);
+            updateTypeTable(data.requestTypeBreakdown);
+            updatePagesTable(data.mostAccessedPages);
+        })
+        .catch(function(err) {
+            console.error('Failed to fetch filtered data:', err);
+        });
+    }
+
+    function restoreUnfilteredTables() {
+        if (!currentData) return;
+        updateStats(currentData);
+        updateBotTable(currentData.botBreakdown);
+        updateTypeTable(currentData.requestTypeBreakdown);
+        updatePagesTable(currentData.mostAccessedPages);
+        applyChartFilterStyles();
+    }
+
     function updateDashboard(data) {
-        var totalEl = document.getElementById('totalRequests');
-        if (totalEl) {
-            totalEl.textContent = data.totalRequests.toLocaleString();
-        }
-
-        var botsEl = document.getElementById('uniqueBots');
-        if (botsEl) {
-            botsEl.textContent = data.botBreakdown.length;
-        }
-
-        var typesEl = document.getElementById('contentTypes');
-        if (typesEl) {
-            typesEl.textContent = data.requestTypeBreakdown.length;
-        }
-
+        updateStats(data);
         renderChart();
         updateBotTable(data.botBreakdown);
         updateTypeTable(data.requestTypeBreakdown);
         updatePagesTable(data.mostAccessedPages);
+    }
+
+    function updateStats(data) {
+        var totalEl = document.getElementById('totalRequests');
+        if (totalEl) {
+            totalEl.textContent = data.totalRequests.toLocaleString();
+        }
+        var botsEl = document.getElementById('uniqueBots');
+        if (botsEl) {
+            botsEl.textContent = data.botBreakdown.length;
+        }
+        var typesEl = document.getElementById('contentTypes');
+        if (typesEl) {
+            typesEl.textContent = data.requestTypeBreakdown.length;
+        }
     }
 
     function renderChart() {
@@ -211,18 +254,22 @@
         });
 
         var datasets = groups.map(function(group, i) {
-            // Build a date→count lookup for this group
             var countByDate = {};
             breakdownData[group].forEach(function(row) {
                 countByDate[row.date] = row.count;
             });
 
             var color = COLORS[i % COLORS.length];
+            var isSelected = activeFilters.length === 0 || activeFilters.indexOf(group) > -1;
+            var displayColor = isSelected ? color : GRAY;
+
             return {
                 label: group,
                 data: labels.map(function(date) { return countByDate[date] || 0; }),
-                backgroundColor: color.bg,
-                borderColor: color.border,
+                backgroundColor: displayColor.bg,
+                borderColor: displayColor.border,
+                _originalBg: color.bg,
+                _originalBorder: color.border,
                 borderWidth: 1,
                 borderRadius: 3,
             };
@@ -252,20 +299,45 @@
                             pointStyle: 'rectRounded',
                             padding: 16,
                             font: { size: 11 },
+                            generateLabels: function(chart) {
+                                var datasets = chart.data.datasets;
+                                return datasets.map(function(ds, i) {
+                                    var isSelected = activeFilters.length === 0 || activeFilters.indexOf(ds.label) > -1;
+                                    return {
+                                        text: ds.label,
+                                        fillStyle: ds._originalBg,
+                                        strokeStyle: ds._originalBorder,
+                                        lineWidth: 1,
+                                        hidden: false,
+                                        datasetIndex: i,
+                                        fontColor: isSelected ? undefined : 'rgba(150, 150, 150, 0.6)',
+                                    };
+                                });
+                            },
                         },
                         onClick: function(e, legendItem) {
                             var clickedLabel = legendItem.text;
+                            filterType = currentView;
 
-                            if (activeFilter && activeFilter.value === clickedLabel) {
-                                // Clicking the active filter clears it
-                                activeFilter = null;
+                            var idx = activeFilters.indexOf(clickedLabel);
+                            if (idx > -1) {
+                                activeFilters.splice(idx, 1);
                             } else {
-                                // Additive: show only this item
-                                activeFilter = { type: currentView, value: clickedLabel };
+                                activeFilters.push(clickedLabel);
                             }
 
+                            if (activeFilters.length === 0) {
+                                filterType = null;
+                            }
+
+                            applyChartFilterStyles();
                             updateFilterIndicator();
-                            fetchData();
+
+                            if (activeFilters.length > 0) {
+                                fetchFilteredTables();
+                            } else {
+                                restoreUnfilteredTables();
+                            }
                         },
                     },
                 },
@@ -284,13 +356,30 @@
         };
     }
 
+    function applyChartFilterStyles() {
+        if (!chart || !chart.data || !chart.data.datasets) return;
+
+        chart.data.datasets.forEach(function(ds) {
+            var isSelected = activeFilters.length === 0 || activeFilters.indexOf(ds.label) > -1;
+            if (isSelected) {
+                ds.backgroundColor = ds._originalBg;
+                ds.borderColor = ds._originalBorder;
+            } else {
+                ds.backgroundColor = GRAY.bg;
+                ds.borderColor = GRAY.border;
+            }
+        });
+
+        chart.update();
+    }
+
     function updateFilterIndicator() {
         var el = document.getElementById('activeFilter');
         var valueEl = document.getElementById('activeFilterValue');
         if (!el || !valueEl) return;
 
-        if (activeFilter) {
-            valueEl.textContent = activeFilter.value;
+        if (activeFilters.length > 0) {
+            valueEl.textContent = activeFilters.join(', ');
             el.style.display = '';
         } else {
             el.style.display = 'none';

--- a/src/web/assets/analytics/js/dashboard.js
+++ b/src/web/assets/analytics/js/dashboard.js
@@ -307,8 +307,8 @@
                                     var isSelected = activeFilters.length === 0 || activeFilters.indexOf(ds.label) > -1;
                                     return {
                                         text: ds.label,
-                                        fillStyle: ds._originalBg,
-                                        strokeStyle: ds._originalBorder,
+                                        fillStyle: isSelected ? ds._originalBg : GRAY.bg,
+                                        strokeStyle: isSelected ? ds._originalBorder : GRAY.border,
                                         lineWidth: 1,
                                         hidden: false,
                                         datasetIndex: i,

--- a/src/web/assets/analytics/js/dashboard.js
+++ b/src/web/assets/analytics/js/dashboard.js
@@ -260,16 +260,18 @@
             });
 
             var color = COLORS[i % COLORS.length];
-            var isSelected = activeFilters.length === 0 || activeFilters.indexOf(group) > -1;
-            var displayColor = isSelected ? color : GRAY;
+            var data = labels.map(function(date) { return countByDate[date] || 0; });
+            var hasFilter = activeFilters.length > 0;
+            var isSelected = !hasFilter || activeFilters.indexOf(group) > -1;
 
             return {
                 label: group,
-                data: labels.map(function(date) { return countByDate[date] || 0; }),
-                backgroundColor: displayColor.bg,
-                borderColor: displayColor.border,
+                data: isSelected ? data.slice() : data.map(function() { return 0; }),
+                backgroundColor: isSelected ? (hasFilter ? color.border : color.bg) : GRAY.bg,
+                borderColor: isSelected ? color.border : GRAY.border,
                 _originalBg: color.bg,
                 _originalBorder: color.border,
+                _originalData: data,
                 borderWidth: 1,
                 borderRadius: 3,
             };
@@ -359,14 +361,19 @@
     function applyChartFilterStyles() {
         if (!chart || !chart.data || !chart.data.datasets) return;
 
+        var hasFilter = activeFilters.length > 0;
+
         chart.data.datasets.forEach(function(ds) {
-            var isSelected = activeFilters.length === 0 || activeFilters.indexOf(ds.label) > -1;
+            var isSelected = !hasFilter || activeFilters.indexOf(ds.label) > -1;
             if (isSelected) {
-                ds.backgroundColor = ds._originalBg;
+                // Full opacity when actively filtered, normal when no filter
+                ds.backgroundColor = hasFilter ? ds._originalBorder : ds._originalBg;
                 ds.borderColor = ds._originalBorder;
+                ds.data = ds._originalData.slice();
             } else {
                 ds.backgroundColor = GRAY.bg;
                 ds.borderColor = GRAY.border;
+                ds.data = ds._originalData.map(function() { return 0; });
             }
         });
 


### PR DESCRIPTION
## Summary

This PR adds interactive filtering to the analytics dashboard, allowing users to click chart legend items to filter all dashboard data (charts, tables, and stats) by bot or request type. The filtering is additive—clicking a legend item shows only that item, and clicking again restores the full view.

## Key Changes

**Frontend (JavaScript)**
- Added `activeFilters` array and `filterType` state to track selected legend items
- Implemented chart legend click handler that toggles filters and updates all dashboard components
- Added visual feedback: filtered items show full opacity, unfiltered items appear grayed out
- Created `fetchFilteredTables()` to request filtered data from the server
- Created `applyChartFilterStyles()` to update chart appearance based on active filters
- Added filter indicator UI showing active filters with a "Clear" button
- Filters are automatically cleared when switching chart views or changing date/site selection
- Changed all `let`/`const` declarations to `var` for consistency

**Backend (PHP)**
- Added `applyFilters()` helper method to `AnalyticsService` to apply optional bot/type filters to queries
- Updated all data-fetching methods to accept optional `$botName` and `$requestType` parameters:
  - `getRequestsOverTime()`
  - `getRequestsOverTimeByBot()`
  - `getRequestsOverTimeByType()`
  - `getBotBreakdown()`
  - `getRequestTypeBreakdown()`
  - `getMostAccessedPages()`
  - `getTotalRequests()`
- Updated `AnalyticsController::actionData()` to parse filter parameters from request and pass them to service methods

**UI/Styling**
- Added `.active-filter` CSS class for the filter indicator display
- Added filter indicator element to the chart header showing active filters and clear button

**Documentation**
- Updated DOCUMENTATION.md with new "Filtering by bot or request type" section explaining the feature
- Updated CHANGELOG.md noting the change to additive filtering behavior

## Implementation Details

- Filters are stored as an array of selected item names, allowing multi-select capability (though UI currently shows one at a time)
- When filters are active, the chart shows only selected items with full opacity; unfiltered items display with 0 height and gray styling
- The backend applies filters at the query level using Yii's `andWhere()` method, supporting both single values and arrays
- Stats cards (Total Requests, Unique Bots, Content Types) now update dynamically based on filtered data
- All tables (bot breakdown, request types, most accessed pages) update via `fetchFilteredTables()` when a filter is applied

https://claude.ai/code/session_01YTRAy9ngyphtgBH6V229st