### PR TITLE
Prune section settings when a site is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deleting a site no longer leaves orphaned section settings in project config. The plugin now prunes its `llm-ready.sectionSettings.*.{siteUid}` entries when a site is removed, so a later `project-config/apply` (or a fresh install of the config) no longer aborts referencing a site that no longer exists.
 - The project config add/update/remove handlers and the install-time rebuild no longer abort with a `SiteNotFoundException` when a section setting references a missing site. `Sites::getSiteByUid()` throws rather than returning null for an unknown UID, which defeated the existing `=== null` guards; lookups now resolve to null and skip the orphaned entry as intended.
+- The install-time rebuild of the section settings table is now best-effort: a single entry that fails to save no longer aborts the plugin install. Failures are logged and skipped, since the table is a cache that the config event listeners repopulate when project config is applied.
 
 ## [1.5.0] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Deleting a site no longer leaves orphaned section settings in project config. The plugin now prunes its `llm-ready.sectionSettings.*.{siteUid}` entries when a site is removed, so a later `project-config/apply` (or a fresh install of the config) no longer aborts referencing a site that no longer exists.
+- The project config add/update/remove handlers and the install-time rebuild no longer abort with a `SiteNotFoundException` when a section setting references a missing site. `Sites::getSiteByUid()` throws rather than returning null for an unknown UID, which defeated the existing `=== null` guards; lookups now resolve to null and skip the orphaned entry as intended.
+
 ## [1.5.0] - 2026-06-12
 
 ### Added

--- a/src/LlmReady.php
+++ b/src/LlmReady.php
@@ -9,13 +9,17 @@ use craft\base\Element;
 use craft\base\Model;
 use craft\base\Plugin;
 use craft\elements\Entry;
+use craft\errors\SiteNotFoundException;
 use craft\events\ConfigEvent;
+use craft\events\DeleteSiteEvent;
 use craft\events\ModelEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\RegisterUserPermissionsEvent;
 use craft\events\TemplateEvent;
+use craft\models\Site;
 use craft\services\Dashboard;
+use craft\services\Sites;
 use craft\services\UserPermissions;
 use craft\web\UrlManager;
 use craft\web\View;
@@ -83,6 +87,7 @@ class LlmReady extends Plugin
         $this->registerDashboardWidget();
         $this->registerCacheInvalidation();
         $this->registerProjectConfigListeners();
+        $this->registerSiteListeners();
     }
 
     public function getCpNavItem(): ?array
@@ -448,6 +453,32 @@ class LlmReady extends Plugin
     }
 
     /**
+     * Register site event listeners to keep project config in sync
+     */
+    private function registerSiteListeners(): void
+    {
+        Event::on(
+            Sites::class,
+            Sites::EVENT_AFTER_DELETE_SITE,
+            [$this, 'handleDeletedSite'],
+        );
+    }
+
+    /**
+     * Returns a site by its UID, or null if no such site exists.
+     *
+     * Sites::getSiteByUid() throws for an unknown UID rather than returning null.
+     */
+    public static function siteByUidOrNull(string $uid): ?Site
+    {
+        try {
+            return Craft::$app->getSites()->getSiteByUid($uid);
+        } catch (SiteNotFoundException) {
+            return null;
+        }
+    }
+
+    /**
      * Handle a section setting being added or updated in project config
      */
     public function handleChangedSectionSetting(ConfigEvent $event): void
@@ -457,8 +488,7 @@ class LlmReady extends Plugin
         $siteUid = $event->tokenMatches[1];
 
         $section = Craft::$app->getEntries()->getSectionByUid($sectionUid);
-        /** @var \craft\models\Site|null $site */
-        $site = Craft::$app->getSites()->getSiteByUid($siteUid);
+        $site = self::siteByUidOrNull($siteUid);
 
         if ($section === null || $site === null) {
             return;
@@ -492,8 +522,7 @@ class LlmReady extends Plugin
         $siteUid = $event->tokenMatches[1];
 
         $section = Craft::$app->getEntries()->getSectionByUid($sectionUid);
-        /** @var \craft\models\Site|null $site */
-        $site = Craft::$app->getSites()->getSiteByUid($siteUid);
+        $site = self::siteByUidOrNull($siteUid);
 
         if ($section === null || $site === null) {
             return;
@@ -503,6 +532,30 @@ class LlmReady extends Plugin
             'sectionId' => $section->id,
             'siteId' => $site->id,
         ]);
+    }
+
+    /**
+     * Prune orphaned section settings from project config when a site is deleted.
+     *
+     * Craft leaves nested plugin config behind on site deletion; the matching DB
+     * rows are already dropped via the section_settings siteId foreign key.
+     */
+    public function handleDeletedSite(DeleteSiteEvent $event): void
+    {
+        $projectConfig = Craft::$app->getProjectConfig();
+
+        // Project config is read-only while it is being applied; the source
+        // environment is responsible for the removal in that case.
+        if ($projectConfig->readOnly) {
+            return;
+        }
+
+        $siteUid = $event->site->uid;
+        $sectionSettings = $projectConfig->get(self::PROJECT_CONFIG_PATH) ?? [];
+
+        foreach (array_keys($sectionSettings) as $sectionUid) {
+            $projectConfig->remove(self::PROJECT_CONFIG_PATH . ".{$sectionUid}.{$siteUid}");
+        }
     }
 
     /**

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -6,6 +6,7 @@ namespace johnfmorton\llmready\migrations;
 
 use Craft;
 use craft\db\Migration;
+use johnfmorton\llmready\LlmReady;
 use johnfmorton\llmready\records\AnalyticsRecord;
 use johnfmorton\llmready\records\SectionSettingRecord;
 
@@ -33,7 +34,7 @@ class Install extends Migration
         $this->dropTableIfExists(SectionSettingRecord::tableName());
 
         // Clean up project config
-        Craft::$app->getProjectConfig()->remove(\johnfmorton\llmready\LlmReady::PROJECT_CONFIG_PATH);
+        Craft::$app->getProjectConfig()->remove(LlmReady::PROJECT_CONFIG_PATH);
 
         return true;
     }
@@ -107,11 +108,10 @@ class Install extends Migration
      */
     private function rebuildFromProjectConfig(): void
     {
-        $configPath = \johnfmorton\llmready\LlmReady::PROJECT_CONFIG_PATH;
+        $configPath = LlmReady::PROJECT_CONFIG_PATH;
         $sectionSettings = Craft::$app->getProjectConfig()->get($configPath) ?? [];
 
         $sectionsService = Craft::$app->getEntries();
-        $sitesService = Craft::$app->getSites();
 
         foreach ($sectionSettings as $sectionUid => $siteConfigs) {
             $section = $sectionsService->getSectionByUid($sectionUid);
@@ -120,8 +120,7 @@ class Install extends Migration
             }
 
             foreach ($siteConfigs as $siteUid => $values) {
-                /** @var \craft\models\Site|null $site */
-                $site = $sitesService->getSiteByUid($siteUid);
+                $site = LlmReady::siteByUidOrNull($siteUid);
                 if ($site === null) {
                     continue;
                 }

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -9,6 +9,7 @@ use craft\db\Migration;
 use johnfmorton\llmready\LlmReady;
 use johnfmorton\llmready\records\AnalyticsRecord;
 use johnfmorton\llmready\records\SectionSettingRecord;
+use Throwable;
 
 /**
  * LLM Ready Install Migration
@@ -115,7 +116,7 @@ class Install extends Migration
 
         foreach ($sectionSettings as $sectionUid => $siteConfigs) {
             $section = $sectionsService->getSectionByUid($sectionUid);
-            if ($section === null) {
+            if ($section === null || !is_array($siteConfigs)) {
                 continue;
             }
 
@@ -125,12 +126,27 @@ class Install extends Migration
                     continue;
                 }
 
-                $record = new SectionSettingRecord();
-                $record->sectionId = $section->id;
-                $record->siteId = $site->id;
-                $record->enabled = $values['enabled'] ?? true;
-                $record->llmTemplate = $values['llmTemplate'] ?? null;
-                $record->save();
+                // Best-effort: skip and log a bad entry rather than failing the install.
+                try {
+                    $record = new SectionSettingRecord();
+                    $record->sectionId = $section->id;
+                    $record->siteId = $site->id;
+                    $record->enabled = $values['enabled'] ?? true;
+                    $record->llmTemplate = $values['llmTemplate'] ?? null;
+
+                    if (!$record->save()) {
+                        Craft::warning(
+                            "Could not rebuild LLM Ready setting for section {$sectionUid} / site {$siteUid}: "
+                            . implode('; ', $record->getFirstErrors()),
+                            __METHOD__,
+                        );
+                    }
+                } catch (Throwable $e) {
+                    Craft::warning(
+                        "Skipped LLM Ready setting for section {$sectionUid} / site {$siteUid}: {$e->getMessage()}",
+                        __METHOD__,
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #18.

## Changes

- Add `siteByUidOrNull()` and route the config handlers and the install-time rebuild through it, so a missing site is skipped as the `=== null` guards already intend instead of throwing.
- Add a `Sites::EVENT_AFTER_DELETE_SITE` handler that prunes `llm-ready.sectionSettings.*.{siteUid}` from project config when a site is deleted.
- Make `rebuildFromProjectConfig()` best-effort: it runs inside the install migration, so a single bad/conflicting entry no longer fails the whole install. Failures are logged and skipped; the table is a cache the config listeners repopulate when project config is applied.

## Testing

Verified locally against a multi-site install: deleting a site now leaves zero references to its UID in `config/project/`, and a fresh `craft setup` / `project-config/apply` no longer throws on a previously-orphaned site reference.